### PR TITLE
Excluir pasta helper

### DIFF
--- a/src/helper/createAsyncSLice.ts
+++ b/src/helper/createAsyncSLice.ts
@@ -1,4 +1,0 @@
-import { createSlice } from "@reduxjs/toolkit";
-
-const createAsyncSlice = 123
-export default createAsyncSlice


### PR DESCRIPTION
Tive um conflito ao fazer o merge entre a upstream/main e minha branch de desenvolvimento local.

Acabei optando por descartar a modificação no arquivo e resolvi deletar a pasta do Helper